### PR TITLE
Автоматическая публикация beta при наличии тригерной строки в commit message

### DIFF
--- a/.github/workflows/post-push.yml
+++ b/.github/workflows/post-push.yml
@@ -25,6 +25,12 @@ jobs:
       # Выпуск beta версии библиотеки, если в commit message есть вхождение строки "deploy_beta"
       - name: Publish beta version
         if: "contains(github.event.head_commit.message, 'deploy_beta')"
-        uses: ./.github/workflows/release.yml
-        with:
-          version: beta
+        run: |
+          CURRENT_VERSION=$(grep -o '"version": "[^"]*' package.json | awk -F'"' '{print $4}')
+          export TAG="beta"
+          export VERSION="$CURRENT_VERSION-beta-$(git rev-parse --short HEAD)"
+          echo "$CURRENT_VERSION"
+          echo "$VERSION"
+        env:
+          token: ${{ secrets.NPM_TOKEN }}
+

--- a/.github/workflows/post-push.yml
+++ b/.github/workflows/post-push.yml
@@ -26,6 +26,6 @@ jobs:
       # Выпуск beta версии библиотеки, если в commit message есть вхождение строки "deploy_beta"
       - name: Publish beta version
         if: "contains(github.event.head_commit.message, 'deploy_beta')"
-        uses: ./.github/workflows/release.yml
+        uses: .github/workflows/release.yml
         with:
           version: beta

--- a/.github/workflows/post-push.yml
+++ b/.github/workflows/post-push.yml
@@ -3,7 +3,6 @@ name: Post push check
 on:
   push
 
-
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -26,6 +25,6 @@ jobs:
       # Выпуск beta версии библиотеки, если в commit message есть вхождение строки "deploy_beta"
       - name: Publish beta version
         if: "contains(github.event.head_commit.message, 'deploy_beta')"
-        uses: ".github/workflows/release.yml"
+        uses: ./.github/workflows/release.yml
         with:
           version: beta

--- a/.github/workflows/post-push.yml
+++ b/.github/workflows/post-push.yml
@@ -32,7 +32,7 @@ jobs:
 
           echo "//registry.npmjs.org/:_authToken=$TOKEN" > ~/.npmrc
 
-          touch .npmrc
+          yarn release
 
           echo "### Выпущена новая версия библиотеки: $VERSION" >> $GITHUB_STEP_SUMMARY
         env:

--- a/.github/workflows/post-push.yml
+++ b/.github/workflows/post-push.yml
@@ -6,8 +6,6 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
 
     steps:
       # Переключение на выбранную при запуске action ветку и скачивание файлов в окружение.

--- a/.github/workflows/post-push.yml
+++ b/.github/workflows/post-push.yml
@@ -22,3 +22,10 @@ jobs:
       # Прогон тестов
       - name: Run tests
         run: yarn test
+
+      # Выпуск beta версии библиотеки, если в commit message есть вхождение строки "deploy_beta"
+      - name: Publish beta version
+        if: "contains(github.event.head_commit.message, 'deploy_beta')"
+        uses: ./.github/workflows/release.yml
+        with:
+          version: beta

--- a/.github/workflows/post-push.yml
+++ b/.github/workflows/post-push.yml
@@ -26,6 +26,6 @@ jobs:
       # Выпуск beta версии библиотеки, если в commit message есть вхождение строки "deploy_beta"
       - name: Publish beta version
         if: "contains(github.event.head_commit.message, 'deploy_beta')"
-        uses: .github/workflows/release.yml
+        uses: ".github/workflows/release.yml"
         with:
           version: beta

--- a/.github/workflows/post-push.yml
+++ b/.github/workflows/post-push.yml
@@ -29,8 +29,12 @@ jobs:
           CURRENT_VERSION=$(grep -o '"version": "[^"]*' package.json | awk -F'"' '{print $4}')
           export TAG="beta"
           export VERSION="$CURRENT_VERSION-beta-$(git rev-parse --short HEAD)"
-          echo "$CURRENT_VERSION"
-          echo "$VERSION"
+
+          echo "//registry.npmjs.org/:_authToken=$TOKEN" > ~/.npmrc
+
+          touch .npmrc
+
+          echo "### Выпущена новая версия библиотеки: $VERSION" >> $GITHUB_STEP_SUMMARY
         env:
-          token: ${{ secrets.NPM_TOKEN }}
+          TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/post-push.yml
+++ b/.github/workflows/post-push.yml
@@ -30,7 +30,7 @@ jobs:
           export TAG="beta"
           export VERSION="$CURRENT_VERSION-beta-$(git rev-parse --short HEAD)"
 
-          echo "//registry.npmjs.org/:_authToken=$TOKEN" > ~/.npmrc
+          echo "//registry.npmjs.org/:_authToken=$TOKEN" > .npmrc
 
           yarn release
 


### PR DESCRIPTION
Добавлена логика по автоматическому выпуску beta версий при наличии строки **deploy_beta** в сообщении коммита.

Решение [issue](https://github.com/core-ds/bridge-to-native/issues/10)

Пример логов post push action при сообщении коммита без тригерной фразы:
<img width="631" alt="Снимок экрана 2024-02-12 в 22 55 04" src="https://github.com/core-ds/bridge-to-native/assets/76172037/ead930ec-5044-45de-a853-492d2d1b09f2">

Пример логов post push action при сообщении коммита с тригерной фразой **deploy_beta**:
<img width="637" alt="Снимок экрана 2024-02-12 в 22 55 28" src="https://github.com/core-ds/bridge-to-native/assets/76172037/9eced629-5bf0-4471-95df-815c648238c5">

<img width="948" alt="Снимок экрана 2024-02-12 в 22 55 49" src="https://github.com/core-ds/bridge-to-native/assets/76172037/a4665dfa-6ef4-47a8-965e-b42267ae0015">

<img width="1224" alt="Снимок экрана 2024-02-12 в 23 13 50" src="https://github.com/core-ds/bridge-to-native/assets/76172037/dd0f8fd0-98c1-41b2-94a8-3547ea900227">



