### PR TITLE
feat(*): handleRedirect accepts historyState now

### DIFF
--- a/src/native-navigation-and-title.ts
+++ b/src/native-navigation-and-title.ts
@@ -84,8 +84,9 @@ export class NativeNavigationAndTitle {
 
     /**
      * @param path Путь для перехода на функциональность внутри приложения.
+     * @param historyState (https://developer.mozilla.org/en-US/docs/Web/API/History/state) для новой записи в истории.
      */
-    handleRedirect(path: string): void;
+    handleRedirect(path: string, historyState?: Record<string, unknown>): void;
     /**
      * В этом варианте аргументы 2,3,4 соответствуют аргументам 1,2,3 метода `src/shared/utils/handle-redirect`.
      *
@@ -93,12 +94,14 @@ export class NativeNavigationAndTitle {
      * @param appName См. первый параметр `src/handle-redirect.ts`.
      * @param path См. второй параметр `src/handle-redirect.ts`.
      * @param params См. третий параметр `src/handle-redirect.ts`.
+     * @param historyState (https://developer.mozilla.org/en-US/docs/Web/API/History/state) для новой записи в истории.
      */
     handleRedirect(
         pageTitle: string,
         appName: string,
         path?: string,
         params?: Record<string, string>,
+        historyState?: Record<string, unknown>,
     ): void;
     /**
      * Метод вызывает `src/shared/utils/handle-redirect` из `newclick-host-ui`
@@ -107,24 +110,37 @@ export class NativeNavigationAndTitle {
      */
     public handleRedirect(
         pageTitleOrPath: string,
-        appName?: string,
+        appNameOrHistoryState?: string | Record<string, unknown>,
         path?: string,
         params?: Record<string, string>,
+        historyState?: Record<string, unknown>,
     ) {
-        if (appName) {
-            this._handleWindowRedirect(appName, path, params);
+        console.log('@@@@@@@@@');
+        const checkAppNameArgument = (argument: unknown): argument is string =>
+            Boolean(appNameOrHistoryState && typeof appNameOrHistoryState === 'string');
+        const isAppNameArgument = checkAppNameArgument(appNameOrHistoryState);
+        console.log('@@@2222222222');
+        if (isAppNameArgument) {
+            this._handleWindowRedirect(appNameOrHistoryState, path, params, historyState);
+            console.log('@@@334343434343');
         } else {
+            console.log('else');
             const {
                 appName: extractedAppName,
                 path: extractedPath,
                 query: extractedQuery,
             } = extractAppNameRouteAndQuery(pageTitleOrPath);
 
-            this._handleWindowRedirect(extractedAppName, extractedPath, extractedQuery);
+            this._handleWindowRedirect(
+                extractedAppName,
+                extractedPath,
+                extractedQuery,
+                appNameOrHistoryState,
+            );
         }
 
-        const title = appName ? pageTitleOrPath : '';
-
+        const title = isAppNameArgument ? pageTitleOrPath : '';
+        console.log('test', this.nativeHistoryStack, this.syncHistoryWithNative);
         this.nativeHistoryStack.push(title);
         this.syncHistoryWithNative(title, 'navigation');
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,7 @@ export type HandleRedirect = (
     appName: string,
     path?: string,
     params?: Record<string, string>,
+    historyState?: Record<string, unknown>,
 ) => void;
 
 export type Theme = 'light' | 'dark';

--- a/test/native-navigation-and-title.test.ts
+++ b/test/native-navigation-and-title.test.ts
@@ -306,7 +306,7 @@ describe('AmNavigationAndTitle', () => {
         });
 
         describe('method `handleRedirect`', () => {
-            it('should pass 2th, 3th and 4th params to `handleRedirect`', () => {
+            it('should pass 2th, 3th, 4th and 5th params to `handleRedirect`', () => {
                 const inst = new NativeNavigationAndTitle(
                     mockedBridgeToNativeInstance,
                     null,
@@ -314,23 +314,34 @@ describe('AmNavigationAndTitle', () => {
                     mockedHandleRedirect,
                 );
 
-                inst.handleRedirect('New Title', 'app-name', 'path', { test: 'test' });
+                inst.handleRedirect('New Title', 'app-name', 'path', { test: 'test' }, { id: 1 });
 
                 expect(mockedHandleRedirect).toBeCalledTimes(1);
-                expect(mockedHandleRedirect).toHaveBeenCalledWith('app-name', 'path', {
-                    test: 'test',
-                });
+                expect(mockedHandleRedirect).toHaveBeenCalledWith(
+                    'app-name',
+                    'path',
+                    {
+                        test: 'test',
+                    },
+                    { id: 1 },
+                );
             });
 
-            it('should work with 1 parameter', () => {
+            it('should work with 2 parameters (path and history state)', () => {
                 const inst = new NativeNavigationAndTitle(
                     mockedBridgeToNativeInstance,
                     null,
                     '',
                     mockedHandleRedirect,
                 );
+                const historyState = {
+                    test: 1,
+                };
 
-                inst.handleRedirect('/app-name/main-path/sub-path?query=test&query1=test1');
+                inst.handleRedirect(
+                    '/app-name/main-path/sub-path?query=test&query1=test1',
+                    historyState,
+                );
 
                 expect(mockedHandleRedirect).toBeCalledTimes(1);
                 expect(mockedHandleRedirect).toHaveBeenCalledWith(
@@ -340,6 +351,7 @@ describe('AmNavigationAndTitle', () => {
                         query: 'test',
                         query1: 'test1',
                     },
+                    historyState,
                 );
 
                 inst.handleRedirect('app-name/main-path');
@@ -347,10 +359,16 @@ describe('AmNavigationAndTitle', () => {
                     'app-name',
                     'main-path',
                     undefined,
+                    undefined,
                 );
 
                 inst.handleRedirect('app-name');
-                expect(mockedHandleRedirect).toHaveBeenCalledWith('app-name', '', undefined);
+                expect(mockedHandleRedirect).toHaveBeenCalledWith(
+                    'app-name',
+                    '',
+                    undefined,
+                    undefined,
+                );
             });
 
             it('should modify inner history stack correctly', () => {
@@ -942,7 +960,12 @@ describe('AmNavigationAndTitle', () => {
 
                 inst.pseudoReloadPage();
 
-                expect(mockedHandleRedirect).toBeCalledWith('blank', '', { reload: 'true' });
+                expect(mockedHandleRedirect).toBeCalledWith(
+                    'blank',
+                    '',
+                    { reload: 'true' },
+                    undefined,
+                );
                 expect(mockedGoBack).toBeCalled();
             });
         });


### PR DESCRIPTION
Добавлен новый аргумент в метод handleRedirect и в метод handleRedirect из bridgeToAm. Появилась идея хранить не примитивные опции для сайд-панели не в стэке, как это было раньше, а в history state. Со стэком уж слишком было все запутано и решили немного упростить логику. Вот для это и нужно было добавить обработку нового аргумента для handleRedirect