### PR TITLE
Фикс бага с потерей контекста в сабклассах

### DIFF
--- a/src/bridge-to-native.ts
+++ b/src/bridge-to-native.ts
@@ -158,7 +158,7 @@ export class BridgeToNative {
     }
 
     public checkAndroidAllowOpenInNewWebview() {
-        const comparisonResult = this?.isCurrentVersionHigherOrEqual(
+        const comparisonResult = this.isCurrentVersionHigherOrEqual(
             START_VERSION_ANDROID_ALLOW_OPEN_NEW_WEBVIEW,
         );
 

--- a/src/bridge-to-native.ts
+++ b/src/bridge-to-native.ts
@@ -158,7 +158,7 @@ export class BridgeToNative {
     }
 
     public checkAndroidAllowOpenInNewWebview() {
-        const comparisonResult = this.isCurrentVersionHigherOrEqual(
+        const comparisonResult = this?.isCurrentVersionHigherOrEqual(
             START_VERSION_ANDROID_ALLOW_OPEN_NEW_WEBVIEW,
         );
 

--- a/src/native-fallbacks.ts
+++ b/src/native-fallbacks.ts
@@ -42,9 +42,9 @@ export class NativeFallbacks {
 
     public getExternalLinkProps(link: string, options: ExternalNavigationOptions = {}) {
         const { onClick, forceOpenInWebview } = options;
-        const { iosAppId, environment, appVersion, checkAndroidAllowOpenInNewWebview } = this.b2n;
+
         const url = getUrlInstance(link);
-        const appId = getAppId(environment, iosAppId);
+        const appId = getAppId(this.b2n.environment, this.b2n.iosAppId);
 
         if (!forceOpenInWebview && this.b2n.canUseNativeFeature('linksInBrowser')) {
             url.searchParams.append('openInBrowser', 'true');
@@ -52,7 +52,7 @@ export class NativeFallbacks {
             return { href: url.href, onClick };
         }
 
-        if (iosAppId || checkAndroidAllowOpenInNewWebview()) {
+        if (this.b2n.iosAppId || this.b2n.checkAndroidAllowOpenInNewWebview()) {
             return {
                 href: `${appId}://webFeature?type=recommendation&url=${encodeURIComponent(
                     url.href,

--- a/src/native-fallbacks.ts
+++ b/src/native-fallbacks.ts
@@ -93,16 +93,14 @@ export class NativeFallbacks {
         let replaceUrl = url;
         const paramsStr = params.toString();
 
-        const { environment, iosAppId } = this.b2n;
-
-        if (environment === 'ios') {
-            replaceUrl = `${iosAppId}:///dashboard/pdf_viewer?${paramsStr}`;
+        if (this.b2n.environment === 'ios') {
+            replaceUrl = `${this.b2n.iosAppId}:///dashboard/pdf_viewer?${paramsStr}`;
         }
 
         // У андройда через диплинк открывается, но предыдущий экран затирается.
         // Поэтому мы открываем base64 через конвертирование в бинарный pdf (через ручки сервиса)
         // Это позволяет перейти назад к вебвью
-        if (environment === 'android' && type === 'base64') {
+        if (this.b2n.environment === 'android' && type === 'base64') {
             replaceUrl = `/services/base64-to-pdf?${paramsStr}`;
         }
 
@@ -119,15 +117,14 @@ export class NativeFallbacks {
      * все ссылки будут открываться в рамках webview, иначе открытие по возможности будет происходить в браузере.
      */
     public visitExternalResource(link: string, forceOpenInWebview = false) {
-        const { iosAppId, appVersion, environment, checkAndroidAllowOpenInNewWebview } = this.b2n;
         const url = getUrlInstance(link);
-        const appId = getAppId(environment, iosAppId);
+        const appId = getAppId(this.b2n.environment, this.b2n.iosAppId);
 
         if (!forceOpenInWebview && this.b2n.canUseNativeFeature('linksInBrowser')) {
             url.searchParams.append('openInBrowser', 'true');
 
             window.location.replace(url.href);
-        } else if (iosAppId || checkAndroidAllowOpenInNewWebview()) {
+        } else if (this.b2n.iosAppId || this.b2n.checkAndroidAllowOpenInNewWebview()) {
             window.location.replace(
                 `${appId}://webFeature?type=recommendation&url=${encodeURIComponent(url.href)}`,
             );


### PR DESCRIPTION
В композитах в маркдаун ссылке используется метод `bridgeToNative?.nativeFallbacks.getExternalLinkProps(href)` 
С прода прилетел такой баг:

<img width="483" alt="Снимок экрана 2024-04-25 в 03 08 37" src="https://github.com/core-ds/bridge-to-native/assets/76172037/ba4ae864-b983-42e4-a818-a48942beafa5">

Опытным путем выяснилось что причина в деструктуризации методов бриджа в его саб-классах: `const { iosAppId, environment, appVersion, checkAndroidAllowOpenInNewWebview } = this.b2n` из-за чего checkAndroidAllowOpenInNewWebview внутри getExternalLinkProps терял контекст. Прошелся по всем саб классам и убрал это от греха.

Демка: 0.0.10-beta-03256e9