### PR TITLE
feat(native-fallbacks.ts): window.open fallback was added

### DIFF
--- a/src/native-fallbacks.ts
+++ b/src/native-fallbacks.ts
@@ -104,7 +104,10 @@ export class NativeFallbacks {
             replaceUrl = `/services/base64-to-pdf?${paramsStr}`;
         }
 
-        window.open(replaceUrl);
+        const windowObjectReference = window.open(replaceUrl);
+        if (windowObjectReference === null) {
+            window.location.replace(replaceUrl);
+        }
     }
 
     /**


### PR DESCRIPTION
Добавлен фолбэк для открытия pdf. Проверял в iPod Touch 7 iOS 15, window.open для данного устройства возвращает null, window.location.replace отрабатывает.