### PR TITLE
Фикс бага после перехода по nativeNavigationAndTitle.navigateInsideASharedSession в Андроид не работает handleRedirect

### DIFF
--- a/src/bridge-to-native.ts
+++ b/src/bridge-to-native.ts
@@ -45,6 +45,7 @@ export class BridgeToNative {
         const previousState = !!sessionStorage.getItem(PREVIOUS_B2N_STATE_STORAGE_KEY);
 
         if (previousState) {
+            this._handleRedirect = handleRedirect;
             this.restorePreviousState();
             this.nativeFallbacks = new NativeFallbacks(this);
             this._blankPagePath = blankPagePath;


### PR DESCRIPTION
На проде обнаружен такой баг.

ОС Андроид.

Если при переходе на новый экран используется метод `nativeNavigationAndTitle.navigateInsideASharedSession`,
то на этом экране при вызове метода `nativeNavigationAndTitle.handleRedirect` выходит такая ошибка:
![Screenshot 2024-08-29 at 14 45 12](https://github.com/user-attachments/assets/95bc770c-fd9c-45f6-af94-7c5835d31b8b)
и соответственно переход не работает.

Причина в том, что при вызове метода this.restorePreviousState() в конструкторе BridgeToNative, значение у this._handleRedirect не установлено.

