### PR TITLE
Добавлена Esm сборка вместо commonJs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,22 @@
         "type": "git",
         "url": "git+https://github.com/core-ds/bridge-to-native.git"
     },
+    "main": "./index.js",
+    "module": "./esm/index.js",
+    "exports": {
+        ".": {
+            "import": "./esm/index.js",
+            "require": "./index.js"
+        },
+        "./*": {
+            "import": "./esm/*",
+            "require": "./*"
+        }
+    },
+    "sideEffects": false,
+    "files": [
+        "*"
+    ],
     "bugs": {
         "url": "https://github.com/core-ds/bridge-to-native/issues"
     },
@@ -13,18 +29,19 @@
     "scripts": {
         "build": "yarn compile",
         "changelog": "bash bin/fill-changelog-file-and-notify-github.sh",
-        "compile": "yarn compile:clean && yarn compile:ts && yarn compile:copy-resources",
+        "compile": "yarn compile:clean && yarn compile:ts && yarn compile:ts:esm && yarn compile:copy-resources",
         "compile:copy-package-json": "shx cp package.json .publish/package.json",
         "compile:copy-resources": "yarn copyfiles -e \"**/*.{[jt]s*(x),snap}\" -e \"**/*.json\" -u 1 \"src/**/*\" .publish",
         "compile:clean": "shx rm -rf .publish",
         "compile:ts": "tsc --project tsconfig.build.json",
+        "compile:ts:esm": "tsc --project tsconfig.build.esm.json",
         "lint:scripts": "eslint \"**/*.{js,jsx,ts,tsx}\" --ext .js,.jsx,.ts,.tsx",
         "lint": "yarn lint:scripts && prettier --check \"./src/*.{ts,tsx,js,jsx,json}\"",
         "lint:fix": "yarn lint:scripts --fix",
         "pub": "npm publish .publish --userconfig \"../.npmrc\" --tag \"$TAG\"",
         "format": "prettier --write \"./**/*.{ts,tsx,js,jsx,css,json}\"",
         "test": "jest --silent --collect-coverage",
-        "release": "yarn compile && npm version \"$VERSION\" --no-git-tag-version && yarn compile:copy-package-json && yarn pub"
+        "release": "yarn build && npm version \"$VERSION\" --no-git-tag-version && yarn compile:copy-package-json && yarn pub"
     },
     "dependencies": {},
     "devDependencies": {

--- a/tsconfig.build.esm.json
+++ b/tsconfig.build.esm.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "./.publish/esm",
+        "target": "ESNext",
+        "module": "ESNext",
+        "removeComments": false,
+        "moduleResolution": "Node",
+    },
+    "exclude": ["test/**/*.*"]
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,11 +1,9 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "target": "ES2019",
-        "module": "CommonJS",
-        "noEmit": false,
-        "composite": false,
-        "removeComments": false
+        "target": "ESNext",
+        "module": "ESNext",
+        "moduleResolution": "Node",
     },
     "exclude": ["test/**/*.*"]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,9 +1,11 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "target": "ESNext",
-        "module": "ESNext",
-        "moduleResolution": "Node",
+        "target": "ES2019",
+        "module": "CommonJS",
+        "noEmit": false,
+        "composite": false,
+        "removeComments": false
     },
     "exclude": ["test/**/*.*"]
 }


### PR DESCRIPTION
Добавлена Esm сборка вместо commonJs.
[Было](https://www.npmjs.com/package/@alfalab/bridge-to-native/v/0.0.13?activeTab=code) [Стало](https://www.npmjs.com/package/@alfalab/bridge-to-native/v/0.0.13-beta-0b05bc4?activeTab=code)